### PR TITLE
avoid logging spurious error when stream is closed

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -186,7 +186,7 @@ module SSE
           # connected but before @cxn was set. Checking the variable again is a bit clunky but avoids that.
           return if @stopped.value
           read_stream(@cxn) if !@cxn.nil?
-        rescue SystemCallError, IOError => e
+        rescue => e
           # When we deliberately close the connection, it will usually trigger an exception. The exact type
           # of exception depends on the specific Ruby runtime. But @stopped will always be set in this case.
           if @stopped.value
@@ -194,9 +194,6 @@ module SSE
           else
             log_and_dispatch_error(e, "Unexpected error from event source")
           end
-        rescue StandardError => e
-          # This should not be possible because connect catches all StandardErrors
-          log_and_dispatch_error(e, "Unexpected error from event source")
         end
         begin
           @cxn.close if !@cxn.nil?
@@ -215,6 +212,7 @@ module SSE
           @logger.info { "Will retry connection after #{'%.3f' % interval} seconds" } 
           sleep(interval)
         end
+        cxn = nil
         begin
           @logger.info { "Connecting to event stream at #{@uri}" }
           cxn = Impl::StreamingHTTPConnection.new(@uri,
@@ -240,11 +238,9 @@ module SSE
             err = Errors::HTTPStatusError.new(cxn.status, body)
             @on[:error].call(err)
           end
-        rescue Errno::EBADF
-          raise # See EBADF comment in run_stream
-        rescue StandardError => e
+        rescue
           cxn.close if !cxn.nil?
-          log_and_dispatch_error(e, "Unexpected error from event source")
+          raise  # will be handled in run_stream
         end
         # if unsuccessful, continue the loop to connect again
       end


### PR DESCRIPTION
https://github.com/launchdarkly/ruby-server-sdk/issues/135

If you start an SSE client and then call `close` on it, the worker thread that is trying to read the stream will get an exception when the socket goes away. This is normal, and we don't want to log it as an error. We were testing for a specific exception class that I thought we would always see in this scenario, but it turns out that that is dependent on the Ruby version and platform (it could be `Errno::EBADF`, or some kind of `IOError`).

This PR changes the logic to be simply "if we know that `close` has already been called, then there's no point in reporting any further exceptions."