### PR TITLE
fix backoff logic to not start at zero and to reset correctly

### DIFF
--- a/lib/ld-eventsource/impl/backoff.rb
+++ b/lib/ld-eventsource/impl/backoff.rb
@@ -14,7 +14,7 @@ module SSE
       # @param [Float] reconnect_reset_interval  the interval will be reset to the minimum if this number of
       #   seconds elapses between the last call to {#mark_success} and the next call to {#next_interval}
       #
-      def initialize(base_interval, max_interval, reconnect_reset_interval: 60)
+      def initialize(base_interval, max_interval, reconnect_reset_interval = 60)
         @base_interval = base_interval
         @max_interval = max_interval
         @reconnect_reset_interval = reconnect_reset_interval
@@ -37,10 +37,6 @@ module SSE
         if !@last_good_time.nil?
           good_duration = Time.now.to_f - @last_good_time
           @attempts = 0 if good_duration >= @reconnect_reset_interval
-        end
-        if @attempts == 0
-          @attempts += 1
-          return 0
         end
         @last_good_time = nil
         target = ([@base_interval * (2 ** @attempts), @max_interval].min).to_f

--- a/lib/ld-eventsource/impl/backoff.rb
+++ b/lib/ld-eventsource/impl/backoff.rb
@@ -14,7 +14,7 @@ module SSE
       # @param [Float] reconnect_reset_interval  the interval will be reset to the minimum if this number of
       #   seconds elapses between the last call to {#mark_success} and the next call to {#next_interval}
       #
-      def initialize(base_interval, max_interval, reconnect_reset_interval = 60)
+      def initialize(base_interval, max_interval, reconnect_reset_interval: 60)
         @base_interval = base_interval
         @max_interval = max_interval
         @reconnect_reset_interval = reconnect_reset_interval

--- a/spec/backoff_spec.rb
+++ b/spec/backoff_spec.rb
@@ -40,6 +40,10 @@ module SSE
         interval = b.next_interval
         expect(interval).to be <= initial
         expect(interval).to be >= initial / 2
+
+        interval = b.next_interval # make sure it continues increasing after that
+        expect(interval).to be <= (initial * 2)
+        expect(interval).to be >= initial
       end
     end
   end

--- a/spec/backoff_spec.rb
+++ b/spec/backoff_spec.rb
@@ -27,7 +27,7 @@ module SSE
         initial = 1.5
         max = 60
         threshold = 2
-        b = Backoff.new(initial, max, threshold)
+        b = Backoff.new(initial, max, reconnect_reset_interval: threshold)
 
         for i in 1..6 do
           # just cause the backoff to increase quickly, don't actually do these delays

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -362,7 +362,7 @@ EOT
       with_client(client) do |client|
         expect(event_sink.pop).to eq(simple_event_1)
         interval = request_times[1] - request_times[0]
-        expect(interval).to be < ((retry_ms.to_f / 1000) + 0.1)
+        expect(interval).to be < 0.5
       end
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -330,7 +330,7 @@ EOT
           expect(event_sink.pop).to eq(simple_event_1)
           if i > 0
             interval = request_times[i] - request_end_times[i - 1]
-            expect(interval).to be <= initial_interval
+            expect(interval).to be <= (initial_interval + 0.1)
           end
         end
       end


### PR DESCRIPTION
The Ruby SSE implementation diverged from the standard LaunchDarkly SSE behavior, and from its own documentation, in two ways:

1. If you set the initial reconnect to delay to (for instance) 1.0, the first reconnection attempt should have used a delay between 0.5 and 1.0; instead, it used _no_ delay, and the _second_ attempt would use the correct initial delay.

2. Worse: if a successful connection remained open for at least `reconnect_reset_interval` (default 60 seconds), instead of correctly resetting to the initial delay for the next failure, it would reset to zero _and continue with zero delay for every subsequent reconnect_. In the case of a sustained network interruption or service outage, that would cause a spike in CPU usage as it attempted to reconnect in a tight loop.

This PR fixes both of those issues. Now, consistent with LaunchDarkly SDK streaming behavior in general (and with the existing documentation for this package), if the initial delay is set to N then the first reconnection attempt will be be in the range [N/2, N], and subsequent reconnections will continue increasing the delay exponentially unless at least `reconnect_reset_interval` has elapsed since the last success, in which case the next delay will start over at [N/2, N] and continue increasing as usual.