### PR TITLE
Expose a listen method to wait on main thread

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -116,7 +116,7 @@ module SSE
 
       yield self if block_given?
 
-      Thread.new do
+      @runner = Thread.new do
         run_stream
       end
     end
@@ -155,6 +155,13 @@ module SSE
     #
     def on_error(&action)
       @on[:error] = action
+    end
+
+    #
+    # Waits on the main stream thread
+    #
+    def listen
+      @runner.join
     end
 
     #


### PR DESCRIPTION
### Use Cases
1. I need to show a client how their team can connect to our SSE server and consume events. I want to demonstrate how to do so with a variety of languages, including Ruby, and want to keep it as simple as possible.

2. I need a simple, plain Ruby script that will consume SSE events from my server and act on them if certain conditions are true.

### The Problem
Because the EventSource `Client` does all of its work in an anonymous thread created on `initialize`, there's no way (that I know of) to simply wait on the main thread. Without this ability, any script that is meant to be bare-bones will immediately exit after defining the client.

### The Solution
My proposed solution is very simple; keep track of the main thread and expose a `listen` method that will allow users to wait patiently for events.

I tested this locally and it worked like a charm!

### Extra notes
 - I know this gem was probably made with Rails in mind, and I don't want to go stomping on the intended use case of this gem, but I think with this simple change it should be able to support the use cases I listed.

 - I'm not sure how to write a test for this. If anyone has a good idea, please let me know and I'll get something in there.


Thanks! Big fan of LaunchDarkly!