### PR TITLE
Expose whether the client is alive

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -190,8 +190,8 @@ module SSE
       end
     end
 
-    def is_alive?
-      !@stopped.value
+    def closed?
+      @stopped.value
     end
 
     private

--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -190,6 +190,10 @@ module SSE
       end
     end
 
+    def is_alive?
+      !@stopped.value
+    end
+
     private
     
     def reset_http


### PR DESCRIPTION
We used this gem for monitoring and found that it was useful to expose the aliveness status of the client to check if we needed to restart it.