### PR TITLE
allow v5.x of http gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ ruby-docker-template: &ruby-docker-template
         fi
     - run: sudo apt-get update -y && sudo apt-get install -y build-essential
     - run: ruby -v
-    - run: gem install bundler -v "~> 1.17"
+    - run: gem install bundler -v 2.2.10
     - run: bundle install
     - run: mkdir ./rspec
     - run: bundle exec rspec --format progress --format RspecJunitFormatter -o ./rspec/rspec.xml spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ ruby-docker-template: &ruby-docker-template
         fi
     - run: sudo apt-get update -y && sudo apt-get install -y build-essential
     - run: ruby -v
-    - run: gem install bundler -v 2.2.10
+    - run: gem install bundler -v "~> 1.17"
     - run: bundle install
     - run: mkdir ./rspec
     - run: bundle exec rspec --format progress --format RspecJunitFormatter -o ./rspec/rspec.xml spec

--- a/ld-eventsource.gemspec
+++ b/ld-eventsource.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webrick", "~> 1.7"
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.4.1"
+  spec.add_runtime_dependency "http", ">= 4.4.1", "< 6.0.0"
 end

--- a/ld-eventsource.gemspec
+++ b/ld-eventsource.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "2.2.10"
+  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.3.0"
   spec.add_development_dependency "webrick", "~> 1.7"

--- a/ld-eventsource.gemspec
+++ b/ld-eventsource.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "2.2.10"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.3.0"
   spec.add_development_dependency "webrick", "~> 1.7"


### PR DESCRIPTION
The [5.0.0 release](https://github.com/httprb/http/blob/v5.0.1/CHANGES.md#500-2021-05-12) of `http` includes numerous improvements, including the removal of the unmaintained `http_parser` gem as a dependency. The breaking changes in 5.0.0 do not affect `ruby-eventsource` (I verified this with the existing CI tests, but also, as described in the changelog the breaking changes only affect code that calls HttpResponse.parse directly or creates a mock HttpResponse, which we don't). Therefore we can loosen our dependency constraint to allow 5.x versions.

Originally I also included a change to the `bundler` version in this PR, but that's unrelated so I'll do it separately.