### PR TITLE
don't apply backoff delay before first connection attempt

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -133,6 +133,7 @@ module SSE
 
       @backoff = Impl::Backoff.new(reconnect_time || DEFAULT_RECONNECT_TIME, MAX_RECONNECT_TIME,
         reconnect_reset_interval: reconnect_reset_interval)
+      @first_attempt = true
 
       @on = { event: ->(_) {}, error: ->(_) {} }
       @last_id = last_event_id
@@ -283,7 +284,8 @@ module SSE
     def connect
       loop do
         return if @stopped.value
-        interval = @backoff.next_interval
+        interval = @first_attempt ? 0 : @backoff.next_interval
+        @first_attempt = false
         if interval > 0
           @logger.info { "Will retry connection after #{'%.3f' % interval} seconds" } 
           sleep(interval)


### PR DESCRIPTION
I noticed that unit tests were running slower than I'd expect. Turning on more verbose logging revealed that it was doing a sleep of 500-1000ms _before_ each connection— in other words, it was applying the backoff delay too soon. This is causing unnecessary slowness in initial connections, both when used in the LaunchDarkly Ruby SDK and when used separately.