### PR TITLE
rewrite buffered line reader logic for better efficiency and testability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run: gem install bundler -v 2.2.10
       - run: bundle _2.2.10_ install
       - run: mkdir ./rspec
-      - run: bundle _2.2.10_ exec rspec --format progress --format RspecJunitFormatter -o ./rspec/rspec.xml spec
+      - run: bundle _2.2.10_ exec rspec --format documentation --format RspecJunitFormatter -o ./rspec/rspec.xml spec
       - store_test_results:
           path: ./rspec
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkmf.log
 .DS_Store
 rspec
 Gemfile.lock
+.ruby-version

--- a/lib/ld-eventsource/impl/buffered_line_reader.rb
+++ b/lib/ld-eventsource/impl/buffered_line_reader.rb
@@ -1,0 +1,75 @@
+
+module SSE
+  module Impl
+    class BufferedLineReader
+      #
+      # Reads a series of data chunks from an enumerator, and returns an enumerator that
+      # parses/aggregates these into text lines. The line terminator may be CR, LF, or
+      # CRLF for each line; terminators are not included in the returned lines. When the
+      # input data runs out, the output enumerator ends and does not include any partially
+      # completed line.
+      #
+      # @param [Enumerator] chunks  an enumerator that will yield strings from a stream
+      # @return [Enumerator]  an enumerator that will yield one line at a time
+      #
+      def self.lines_from(chunks)
+        buffer = ""
+        position = 0
+        line_start = 0
+        last_char_was_cr = false
+
+        Enumerator.new do |gen|
+          chunks.each do |chunk|
+            buffer << chunk
+
+            loop do
+              # Search for a line break in any part of the buffer that we haven't yet seen.
+              i = buffer.index(/[\r\n]/, position)
+              if i.nil?
+                # There isn't a line break yet, so we'll keep accumulating data in the buffer, using
+                # position to keep track of where we left off scanning. We can also discard any previously
+                # parsed lines from the buffer at this point.
+                if line_start > 0
+                  buffer.slice!(0, line_start)
+                  line_start = 0
+                end
+                position = buffer.length
+                break
+              end
+
+              ch = buffer[i]
+              if i == 0 && ch == "\n" && last_char_was_cr
+                # This is just the dangling LF of a CRLF pair
+                last_char_was_cr = false
+                i += 1
+                position = i
+                line_start = i
+                next
+              end
+
+              line = buffer[line_start, i - line_start]
+              last_char_was_cr = false
+              i += 1
+              if ch == "\r"
+                if i == buffer.length
+                  last_char_was_cr = true # We'll break the line here, but be on watch for a dangling LF
+                elsif buffer[i] == "\n"
+                  i += 1
+                end
+              end
+              if i == buffer.length
+                buffer = ""
+                i = 0
+              end
+              position = i
+              line_start = i
+              # position = 0  # Next time we're looking for a line break, we'll start at the beginning
+              # line = buffer.slice!(0, i + 1).force_encoding(Encoding::UTF_8).chomp!
+              gen.yield line
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ld-eventsource/impl/event_parser.rb
+++ b/lib/ld-eventsource/impl/event_parser.rb
@@ -20,7 +20,8 @@ module SSE
       #
       # Constructs an instance of EventParser.
       #
-      # @param [Enumerator] lines  an enumerator that will yield one line of text at a time
+      # @param [Enumerator] lines  an enumerator that will yield one line of text at a time;
+      #   the lines should not include line terminators
       #
       def initialize(lines)
         @lines = lines
@@ -31,7 +32,6 @@ module SSE
       def items
         Enumerator.new do |gen|
           @lines.each do |line|
-            line.chomp!
             if line.empty?
               event = maybe_create_event
               reset_buffers

--- a/spec/buffered_line_reader_spec.rb
+++ b/spec/buffered_line_reader_spec.rb
@@ -1,0 +1,62 @@
+require "ld-eventsource/impl/buffered_line_reader"
+
+def tests_for_terminator(term, desc)
+  def make_tests(name, input_line_chunks, expected_lines)
+    [{
+      name: "#{name}: one chunk per line",
+      chunks: input_line_chunks,
+      expected: expected_lines
+    }].concat(
+      (1..4).map do |size|
+        ({
+          name: "#{name}: #{size}-character chunks",
+          chunks: input_line_chunks.join().chars.to_a.each_slice(size).map { |a| a.join },
+          expected: expected_lines
+        })
+      end
+    )
+  end
+  [
+    make_tests("non-empty lines",
+      ["first line" + term, "second line" + term, "3rd line" + term],
+      ["first line", "second line", "3rd line"]),
+
+    make_tests("empty first line",
+      [term, "second line" + term, "3rd line" + term],
+      ["", "second line", "3rd line"]),
+
+    make_tests("empty middle line",
+      ["first line" + term, term, "3rd line" + term],
+      ["first line", "", "3rd line"]),
+
+    make_tests("series of empty lines",
+      ["first line" + term, term, term, term, "3rd line" + term],
+      ["first line", "", "", "", "3rd line"]),
+
+    make_tests("multi-line chunks",
+      ["first line" + term + "second line" + term + "third",
+       " line" + term + "fourth line" + term],
+      ["first line", "second line", "third line", "fourth line"])
+  ].flatten
+end
+
+describe SSE::Impl::BufferedLineReader do
+  subject { SSE::Impl::BufferedLineReader }
+
+  terminators = {
+    "CR": "\r",
+    "LF": "\n",
+    "CRLF": "\r\n"
+  }
+
+  terminators.each do |desc, term|
+    describe "#{desc} terminator" do
+      tests_for_terminator(term, desc).each do |test|
+        it test[:name] do
+          lines = subject.lines_from(test[:chunks])
+          expect(lines.to_a).to eq(test[:expected])
+        end
+      end
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,4 +1,5 @@
 require "ld-eventsource"
+require "http_stub"
 
 #
 # End-to-end tests of the SSE client against a real server

--- a/spec/event_parser_spec.rb
+++ b/spec/event_parser_spec.rb
@@ -5,10 +5,10 @@ describe SSE::Impl::EventParser do
 
   it "parses an event with all fields" do
     lines = [
-      "event: abc\r\n",
-      "data: def\r\n",
-      "id: 1\r\n",
-      "\r\n"
+      "event: abc",
+      "data: def",
+      "id: 1",
+      ""
     ]
     ep = subject.new(lines)
     
@@ -19,8 +19,8 @@ describe SSE::Impl::EventParser do
 
   it "parses an event with only data" do
     lines = [
-      "data: def\r\n",
-      "\r\n"
+      "data: def",
+      ""
     ]
     ep = subject.new(lines)
     
@@ -31,9 +31,9 @@ describe SSE::Impl::EventParser do
 
   it "parses an event with multi-line data" do
     lines = [
-      "data: def\r\n",
-      "data: ghi\r\n",
-      "\r\n"
+      "data: def",
+      "data: ghi",
+      ""
     ]
     ep = subject.new(lines)
     
@@ -45,9 +45,9 @@ describe SSE::Impl::EventParser do
   it "ignores comments" do
     lines = [
       ":",
-      "data: def\r\n",
+      "data: def",
       ":",
-      "\r\n"
+      ""
     ]
     ep = subject.new(lines)
     
@@ -58,8 +58,8 @@ describe SSE::Impl::EventParser do
 
   it "parses reconnect interval" do
     lines = [
-      "retry: 2500\r\n",
-      "\r\n"
+      "retry: 2500",
+      ""
     ]
     ep = subject.new(lines)
 
@@ -70,12 +70,12 @@ describe SSE::Impl::EventParser do
 
   it "parses multiple events" do
     lines = [
-      "event: abc\r\n",
-      "data: def\r\n",
-      "id: 1\r\n",
-      "\r\n",
-      "data: ghi\r\n",
-      "\r\n"
+      "event: abc",
+      "data: def",
+      "id: 1",
+      "",
+      "data: ghi",
+      ""
     ]
     ep = subject.new(lines)
     
@@ -87,10 +87,10 @@ describe SSE::Impl::EventParser do
 
   it "ignores events with no data" do
     lines = [
-      "event: nothing\r\n",
-      "\r\n",
-      "event: nada\r\n",
-      "\r\n"
+      "event: nothing",
+      "",
+      "event: nada",
+      ""
     ]
     ep = subject.new(lines)
     


### PR DESCRIPTION
As described in https://github.com/launchdarkly/ruby-eventsource/issues/20, the current logic for parsing the response stream into lines was very inefficient in any scenario where a long line might be delivered in multiple chunks. It was also difficult to test this logic due to the way it was embedded in `SSE::Client`, and there was at least one edge case it didn't handle correctly (a CR+LF line terminator being split across two chunks).

This PR factors out the buffered line reader logic into its own class, using a more abstract model where it reads any kind of enumerator of string chunks and generates an enumerator of lines, so we can test it without using an HTTP connection. The logic is improved as follows:

* If we've scanned the current buffer and haven't yet found a line break, after reading the next chunk into the buffer we now resume scanning where we left off, instead of at the start of the buffer. This was the basic improvement suggested in https://github.com/launchdarkly/ruby-eventsource/issues/20.
* If the buffer contains multiple lines of text, previously we were calling `slice!` to cut each line out of the start of the buffer and move the remaining content up. That's potentially a lot of unnecessary string modifications. Instead, we can just keep track of where we started scanning the next line (`line_start`), emit substrings as we go along without modifying the buffer, and only remove content from the buffer after we've parsed all the lines.
* If we hit a CR terminator, set a flag so that any LF immediately following that CR will be skipped instead of treating it as a separate line terminator. Previously we were only doing this right if the CRLF appeared together in the same chunk of data; now we also do it right if the CR was at the end of a chunk.