### PR TITLE
remove reliance on git in gemspec

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -18,6 +18,5 @@ branches:
 jobs:
   - docker:
       image: ruby:2.5-buster
-      copyGitHistory: true  # building gem requires git metadata due to use of "git ls-files" in the gemspec
     template:
       name: ruby

--- a/ld-eventsource.gemspec
+++ b/ld-eventsource.gemspec
@@ -3,6 +3,7 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ld-eventsource/version"
+require "rake"
 
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
@@ -15,9 +16,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/launchdarkly/ruby-eventsource"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = FileList["lib/**/*", "README.md", "LICENSE"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "2.2.10"


### PR DESCRIPTION
This commit changes the way we build the gem file by removing the reliance on
git, enabling us to build the gem outside the context of a repository.

Originally this gem would have been built with all tracked files. As this isn't
necessary, this commit also reduces the files that are included in the gem to a
few key top-level files, and everything under lib.
