### PR TITLE
misc fixes to handling of "id" field; add last_event_id to StreamEvent

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -315,7 +315,7 @@ module SSE
           end
         end
       end
-      event_parser = Impl::EventParser.new(Impl::BufferedLineReader.lines_from(chunks))
+      event_parser = Impl::EventParser.new(Impl::BufferedLineReader.lines_from(chunks), @last_id)
 
       event_parser.items.each do |item|
         return if @stopped.value
@@ -331,7 +331,7 @@ module SSE
 
     def dispatch_event(event)
       @logger.debug { "Received event: #{event}" }
-      @last_id = event.id
+      @last_id = event.id if !event.id.nil?
 
       # Pass the event to the caller
       @on[:event].call(event)
@@ -354,7 +354,7 @@ module SSE
         'Cache-Control' => 'no-cache',
         'User-Agent' => 'ruby-eventsource'
       }
-      h['Last-Event-Id'] = @last_id if !@last_id.nil?
+      h['Last-Event-Id'] = @last_id if !@last_id.nil? && @last_id != ""
       h.merge(@headers)
     end
   end

--- a/lib/ld-eventsource/events.rb
+++ b/lib/ld-eventsource/events.rb
@@ -11,6 +11,10 @@ module SSE
   #     if there were multiple `data:` lines, they are concatenated with newlines
   # @!attribute id
   #   @return [String] the string that appeared after `id:` in the stream if any, or nil
+  # @!attribute last_event_id
+  #   @return [String] the most recent non-empty `id:` value that has been seen in an
+  #     event from this stream; this differs from the `id` property in that it retains
+  #     the same value in subsequent events if they do not provide their own `id:`
   #
-  StreamEvent = Struct.new(:type, :data, :id)
+  StreamEvent = Struct.new(:type, :data, :id, :last_event_id)
 end

--- a/lib/ld-eventsource/events.rb
+++ b/lib/ld-eventsource/events.rb
@@ -12,9 +12,9 @@ module SSE
   # @!attribute id
   #   @return [String] the string that appeared after `id:` in the stream if any, or nil
   # @!attribute last_event_id
-  #   @return [String] the most recent non-empty `id:` value that has been seen in an
-  #     event from this stream; this differs from the `id` property in that it retains
-  #     the same value in subsequent events if they do not provide their own `id:`
+  #   @return [String] the most `id:` value that has been seen in an event from this
+  #     stream; this differs from the `id` property in that it retains the same value in
+  #     subsequent events if they do not provide their own `id:`
   #
   StreamEvent = Struct.new(:type, :data, :id, :last_event_id)
 end

--- a/lib/ld-eventsource/events.rb
+++ b/lib/ld-eventsource/events.rb
@@ -12,9 +12,9 @@ module SSE
   # @!attribute id
   #   @return [String] the string that appeared after `id:` in the stream if any, or nil
   # @!attribute last_event_id
-  #   @return [String] the most `id:` value that has been seen in an event from this
-  #     stream; this differs from the `id` property in that it retains the same value in
-  #     subsequent events if they do not provide their own `id:`
+  #   @return [String] the most recent `id:` value that has been seen in an event from
+  #     this stream; this differs from the `id` property in that it retains the same value
+  #     in subsequent events if they do not provide their own `id:`
   #
   StreamEvent = Struct.new(:type, :data, :id, :last_event_id)
 end

--- a/lib/ld-eventsource/events.rb
+++ b/lib/ld-eventsource/events.rb
@@ -12,7 +12,7 @@ module SSE
   # @!attribute id
   #   @return [String] the string that appeared after `id:` in the stream if any, or nil
   # @!attribute last_event_id
-  #   @return [String] the most recent `id:` value that has been seen in an event from
+  #   @return [String] the `id:` value that was most recently seen in an event from
   #     this stream; this differs from the `id` property in that it retains the same value
   #     in subsequent events if they do not provide their own `id:`
   #

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,19 +7,31 @@ require "http_stub"
 describe SSE::Client do
   subject { SSE::Client }
 
-  let(:simple_event_1) { SSE::StreamEvent.new(:go, "foo", "a")}
-  let(:simple_event_2) { SSE::StreamEvent.new(:stop, "bar", "b")}
+  let(:simple_event_1) { SSE::StreamEvent.new(:go, "foo")}
+  let(:simple_event_2) { SSE::StreamEvent.new(:stop, "bar")}
+  let(:event_with_id_1) { SSE::StreamEvent.new(:withid, "foo", "a")}
+  let(:event_with_id_2) { SSE::StreamEvent.new(:withid, "foo", "b")}
   let(:simple_event_1_text) { <<-EOT
 event: go
 data: foo
-id: a
 
 EOT
   }
   let(:simple_event_2_text) { <<-EOT
 event: stop
 data: bar
-id: b
+
+EOT
+  }
+  let(:event_with_id_1_text) { <<-EOT
+event: withid
+data: foo
+
+EOT
+  }
+  let(:event_with_id_2_text) { <<-EOT
+event: stop
+data: bar
 
 EOT
   }
@@ -254,8 +266,11 @@ EOT
       server.setup_response("/") do |req,res|
         requests << req
         attempt += 1
-        send_stream_content(res, attempt == 1 ? simple_event_1_text : simple_event_2_text,
-          keep_open: attempt == 2)
+        if attempt == 1
+          send_stream_content(res, "data: foo\nid: a\n\n", keep_open: false)
+        else
+          send_stream_content(res, "data: bar\nid: b\n\n", keep_open: true)
+        end
       end
 
       event_sink = Queue.new
@@ -266,7 +281,7 @@ EOT
       with_client(client) do |client|
         req1 = requests.pop
         req2 = requests.pop
-        expect(req2.header["last-event-id"]).to eq([ simple_event_1.id ])
+        expect(req2.header["last-event-id"]).to eq([ "a" ])
       end
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,8 +9,6 @@ describe SSE::Client do
 
   let(:simple_event_1) { SSE::StreamEvent.new(:go, "foo")}
   let(:simple_event_2) { SSE::StreamEvent.new(:stop, "bar")}
-  let(:event_with_id_1) { SSE::StreamEvent.new(:withid, "foo", "a")}
-  let(:event_with_id_2) { SSE::StreamEvent.new(:withid, "foo", "b")}
   let(:simple_event_1_text) { <<-EOT
 event: go
 data: foo
@@ -18,18 +16,6 @@ data: foo
 EOT
   }
   let(:simple_event_2_text) { <<-EOT
-event: stop
-data: bar
-
-EOT
-  }
-  let(:event_with_id_1_text) { <<-EOT
-event: withid
-data: foo
-
-EOT
-  }
-  let(:event_with_id_2_text) { <<-EOT
 event: stop
 data: bar
 


### PR DESCRIPTION
Per the [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events), the `id:` field of events should be handled like so:

* The stream client maintains a "last event ID string" variable.
* Any event received from the stream _may_ have an `id:` field.
* If the `id:` field is present (even if it's empty), overwrite "last event ID string" with the new value.
* When returning events to the application, each event should include the "last event ID string" value.

This means that if we receive an event with `id: a` and then we receive a second event with no `id:`, the second event should still include the "a". And, if we have to reconnect the stream after that, we'll send "a" in the Last-Event-Id header.

Ruby-eventsource was instead overwriting "last event ID string" _every time it received an event_, even if that event did not have an `id:`. So, the behavior would only be correct if _every_ event had one; otherwise it would inappropriately reset the field to nil.

For backward compatibility, what I've done here is to add a new `last_event_id` field to the `StreamEvent` type, which behaves the way the spec says it should. The existing `id` field in `StreamEvent` continues to behave the old way. We could change this in a future major version release, but arguably it's nice to give the application a way to know whether or not a particular event did have its own ID, so maybe we should retain both.

I also fixed the handling of the Last-Event-Id header so that we only send one if it's not nil _and not empty_ (per the spec).

I verified that all of the `id`-related SSE contract tests pass with this fix, if I adjust the test service code to use the new `event.last_event_id` rather than `event.id`. So, after merging this change, I'll merge forward into https://github.com/launchdarkly/ruby-eventsource/pull/25 and make that adjustment too.