### PR TITLE
add JRuby 9.3 CI job and disable flaky tests in JRuby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ workflows:
           name: JRuby 9.2
           docker-image: jruby:9.2-jdk
           jruby: true
+      - build-test-linux:
+          name: JRuby 9.3
+          docker-image: jruby:9.3-jdk
+          jruby: true
 
 jobs:
   build-test-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
           name: JRuby 9.2
           docker-image: jruby:9.2-jdk
           jruby: true
+          skip-end-to-end-http-tests: 1  # webrick doesn't work reliably in JRuby 9.2
       - build-test-linux:
           name: JRuby 9.3
           docker-image: jruby:9.3-jdk
@@ -33,9 +34,15 @@ jobs:
       jruby:
         type: boolean
         default: false
+      skip-end-to-end-http-tests:
+        type: string
+        default: ""
 
     docker:
       - image: <<parameters.docker-image>>
+
+    env:
+      LD_SKIP_END_TO_END_HTTP_TESTS: <<parameters.skip-end-to-end-http-tests>>
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,12 @@ workflows:
           name: JRuby 9.2
           docker-image: jruby:9.2-jdk
           jruby: true
-          skip-end-to-end-http-tests: "y"  # webrick doesn't work reliably in JRuby 9.2
+          skip-end-to-end-http-tests: "y"  # webrick doesn't work reliably in JRuby
       - build-test-linux:
           name: JRuby 9.3
           docker-image: jruby:9.3-jdk
           jruby: true
+          skip-end-to-end-http-tests: "y"  # webrick doesn't work reliably in JRuby
 
 jobs:
   build-test-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           name: JRuby 9.2
           docker-image: jruby:9.2-jdk
           jruby: true
-          skip-end-to-end-http-tests: 1  # webrick doesn't work reliably in JRuby 9.2
+          skip-end-to-end-http-tests: "y"  # webrick doesn't work reliably in JRuby 9.2
       - build-test-linux:
           name: JRuby 9.3
           docker-image: jruby:9.3-jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,8 @@ jobs:
 
     docker:
       - image: <<parameters.docker-image>>
-
-    env:
-      LD_SKIP_END_TO_END_HTTP_TESTS: <<parameters.skip-end-to-end-http-tests>>
+        environment:
+          LD_SKIP_END_TO_END_HTTP_TESTS: <<parameters.skip-end-to-end-http-tests>>
 
     steps:
       - checkout

--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -306,6 +306,9 @@ module SSE
           else
             begin
               data = cxn.readpartial
+              # readpartial gives us a string, which may not be a valid UTF-8 string because a
+              # multi-byte character might not yet have been fully read, but BufferedLineReader
+              # will handle that.
             rescue HTTP::TimeoutError 
               # For historical reasons, we rethrow this as our own type
               raise Errors::ReadTimeoutError.new(@read_timeout)

--- a/lib/ld-eventsource/impl/buffered_line_reader.rb
+++ b/lib/ld-eventsource/impl/buffered_line_reader.rb
@@ -9,17 +9,21 @@ module SSE
       # input data runs out, the output enumerator ends and does not include any partially
       # completed line.
       #
-      # @param [Enumerator] chunks  an enumerator that will yield strings from a stream
-      # @return [Enumerator]  an enumerator that will yield one line at a time
+      # @param [Enumerator] chunks  an enumerator that will yield strings from a stream -
+      #  these are treated as raw UTF-8 bytes, regardless of the string's declared encoding
+      #  (so it is OK if a multi-byte character is split across chunks); if the declared
+      #  encoding of the chunk is not ASCII-8BIT, it will be changed to ASCII-8BIT in place
+      # @return [Enumerator]  an enumerator that will yield one line at a time in UTF-8
       #
       def self.lines_from(chunks)
-        buffer = ""
+        buffer = "".b
         position = 0
         line_start = 0
         last_char_was_cr = false
 
         Enumerator.new do |gen|
           chunks.each do |chunk|
+            chunk.force_encoding("ASCII-8BIT")
             buffer << chunk
 
             loop do
@@ -47,7 +51,12 @@ module SSE
                 next
               end
 
-              line = buffer[line_start, i - line_start]
+              line = buffer[line_start, i - line_start].force_encoding("UTF-8")
+              # Calling force_encoding just declares that we believe the encoding of this string to be
+              # UTF-8 (which is the only encoding allowed in the SSE protocol); it doesn't cause any
+              # re-decoding of the string. The previous line-parsing steps were done on raw 8-bit
+              # strings so that it won't try to do any UTF-8 decoding on intermediate slices.
+
               last_char_was_cr = false
               i += 1
               if ch == "\r"

--- a/spec/buffered_line_reader_spec.rb
+++ b/spec/buffered_line_reader_spec.rb
@@ -74,4 +74,24 @@ describe SSE::Impl::BufferedLineReader do
       "fourth line", "", "last"]
     expect(subject.lines_from(chunks).to_a).to eq(expected)
   end
+
+  it "decodes from UTF-8" do
+    text = "abc€豆腐xyz"
+    chunks = [(text + "\n").encode("UTF-8").b]
+    expected = [text]
+    expect(subject.lines_from(chunks).to_a).to eq(expected)
+  end
+
+  it "decodes from UTF-8 when multi-byte characters are split across chunks" do
+    text = "abc€豆腐xyz"
+    raw = (text + "\n").encode("UTF-8").b
+    chunks = raw.bytes.to_a.map{ |byte| byte.chr.force_encoding("UTF-8") }
+    # Calling force_encoding("UTF-8") here simulates the behavior of the http gem's
+    # readpartial method. It actually returns undecoded bytes that might include an
+    # incomplete multi-byte character, but the string's decoding could still be
+    # declared as UTF-8. So we are making sure that BufferedLineReader correctly
+    # handles such a case.
+    expected = [text]
+    expect(subject.lines_from(chunks).to_a).to eq(expected)
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,6 +5,10 @@ require "http_stub"
 # End-to-end tests of the SSE client against a real server
 #
 describe SSE::Client do
+  before(:each) do
+    skip("end-to-end HTTP tests are disabled because they're unreliable on this platform") if !stub_http_server_available?
+  end
+
   subject { SSE::Client }
 
   let(:simple_event_1) { SSE::StreamEvent.new(:go, "foo")}

--- a/spec/http_stub.rb
+++ b/spec/http_stub.rb
@@ -2,6 +2,11 @@ require "webrick"
 require "webrick/httpproxy"
 require "webrick/https"
 
+def stub_http_server_available?
+  flag = ENV["LD_SKIP_END_TO_END_HTTP_TESTS"]
+  flag.nil? || flag == ""
+end
+
 class StubHTTPServer
   attr_reader :port
 


### PR DESCRIPTION
I've seen frequent intermittent failures in the JRuby 9.2 CI job for ruby-eventsource. These all seem to involve unexpected behavior of the embedded HTTP server that we're using to provide fake stream data in the tests. In some cases, requests time out as if the server is unavailable (or maybe it's just very slow - these tests run significantly slower in JRuby even when they do pass); other times, the client receives a malformed HTTP response.

Failures like this don't indicate a problem in the SSE client logic itself; the test infrastructure is breaking somehow, and when that happens, it doesn't get far enough to test the SSE client logic. The embedded HTTP server we're using is `webrick`, and I can only assume `webrick` isn't reliable in JRuby 9.2— at least, not when you're sending chunked stream responses as we're doing, which I imagine is probably not a very common use of `webrick`. And on adding a JRuby 9.3 CI job (which we would've wanted to do anyway), I found that similar failures also happen intermittently in 9.3.

I see that at least one [known JRuby 9.2 issue](https://github.com/jruby/jruby/issues/6171) affecting `webrick` was fixed in 9.3, but clearly there are still some there issues. I don't know of a good alternative to `webrick` for this kind of thing, so it may simply be impossible to make these tests work reliably in JRuby.

So, this PR adds a CI job for JRuby 9.3, and uses a new switch to disable the end-to-end tests that use an embedded server in the 9.2 and 9.3 jobs. The lower-level tests of components like the event parser are still run in JRuby, and the full test suite is still run in every version of ordinary Ruby.

That means a gap in our cross-platform test coverage. However, as soon as we have the SSE _contract_ tests in place for this project, I think it's likely that those will be reliable for JRuby (because the fake stream data comes from a separate app written in Go, not from `webrick`), and their coverage is the same as or better than these unit tests. At that point we may want to consider also reducing the number of such tests that are implemented here in Ruby code, if they are duplicated by the contract tests. Running an embedded server that does streaming correctly is something that's hard to do in a lot of languages, not just Ruby, and that was one rationale for the contract test harness design.