### PR TITLE
fix error when delay is zero in JRuby

### DIFF
--- a/lib/ld-eventsource/impl/backoff.rb
+++ b/lib/ld-eventsource/impl/backoff.rb
@@ -41,7 +41,11 @@ module SSE
         @last_good_time = nil
         target = ([@base_interval * (2 ** @attempts), @max_interval].min).to_f
         @attempts += 1
-        (target / 2) + @jitter_rand.rand(target / 2)
+        if target == 0
+          0  # in some Ruby versions it's illegal to call rand(0)
+        else
+          (target / 2) + @jitter_rand.rand(target / 2)
+        end
       end
 
       #

--- a/spec/backoff_spec.rb
+++ b/spec/backoff_spec.rb
@@ -47,6 +47,17 @@ module SSE
         expect(interval).to be <= (initial * 2)
         expect(interval).to be >= initial
       end
+
+      it "always returns zero if the initial delay is zero" do
+        initial = 0
+        max = 60
+        b = Backoff.new(initial, max)
+        
+        for i in 1..6 do
+          interval = b.next_interval
+          expect(interval).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We're doing a random number calculation which causes an ArgumentError, in JRuby only, if the parameter is zero. This could happen when using the Ruby SDK, or when using ruby-eventsource outside of the SDK, if the application explicitly sets the initial reconnect delay to zero.

I found this problem by running the SSE contract tests— after [disabling other flaky tests in JRuby](https://github.com/launchdarkly/ruby-eventsource/pull/27) that were preventing the CI job from getting that far.