### PR TITLE
fix error when multi-byte character is split across reads

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -306,6 +306,9 @@ module SSE
           else
             begin
               data = cxn.readpartial
+              # readpartial gives us a string, which may not be a valid UTF-8 string because a
+              # multi-byte character might not yet have been fully read, but BufferedLineReader
+              # will handle that.
             rescue HTTP::TimeoutError 
               # For historical reasons, we rethrow this as our own type
               raise Errors::ReadTimeoutError.new(@read_timeout)

--- a/lib/ld-eventsource/impl/buffered_line_reader.rb
+++ b/lib/ld-eventsource/impl/buffered_line_reader.rb
@@ -9,9 +9,10 @@ module SSE
       # input data runs out, the output enumerator ends and does not include any partially
       # completed line.
       #
-      # @param [Enumerator] chunks  an enumerator that will yield strings from a stream;
+      # @param [Enumerator] chunks  an enumerator that will yield strings from a stream -
       #  these are treated as raw UTF-8 bytes, regardless of the string's declared encoding
-      #  (so it is OK if a multi-byte character is split across chunks)
+      #  (so it is OK if a multi-byte character is split across chunks); if the declared
+      #  encoding of the chunk is not ASCII-8BIT, it will be changed to ASCII-8BIT in place
       # @return [Enumerator]  an enumerator that will yield one line at a time in UTF-8
       #
       def self.lines_from(chunks)
@@ -22,7 +23,8 @@ module SSE
 
         Enumerator.new do |gen|
           chunks.each do |chunk|
-            buffer << chunk.b
+            chunk.force_encoding("ASCII-8BIT")
+            buffer << chunk
 
             loop do
               # Search for a line break in any part of the buffer that we haven't yet seen.

--- a/spec/buffered_line_reader_spec.rb
+++ b/spec/buffered_line_reader_spec.rb
@@ -74,4 +74,19 @@ describe SSE::Impl::BufferedLineReader do
       "fourth line", "", "last"]
     expect(subject.lines_from(chunks).to_a).to eq(expected)
   end
+
+  it "decodes from UTF-8" do
+    text = "abc€豆腐xyz"
+    chunks = [(text + "\n").encode("UTF-8").b]
+    expected = [text]
+    expect(subject.lines_from(chunks).to_a).to eq(expected)
+  end
+
+  it "decodes from UTF-8 when multi-byte characters are split across chunks" do
+    text = "abc€豆腐xyz"
+    chunks = (text + "\n").encode("UTF-8").b.
+      chars.each_slice(1).map { |a| a.join }
+      expected = [text]
+    expect(subject.lines_from(chunks).to_a).to eq(expected)
+  end
 end


### PR DESCRIPTION
The solution to this turned out to be pretty simple. The `http` gem doesn't complain about this situation— it just gives us chunks of bytes, without trying to decode them. However, the returned chunk is a string whose declared encoding is UTF-8. If we try to do string manipulations with this, Ruby may try to decode the UTF-8 characters at that point and it'll fail if there's an incomplete character.

So the solution is to make sure all of our strings have a declared encoding of ASCII-8BIT (they're not really ASCII, but this tells Ruby to treat each byte as a character and not interpret it) until we have parsed out a full line.

Unlike some of the other spec compliance issues I fixed recently, this one really could affect the LaunchDarkly SDK. There was a similar issue in Python that was known to cause problems if the flag data included lots of multi-byte characters (the more of them there were, the more chance of hitting the problem) and I'm fairly sure that the same would happen here.