### PR TITLE
#38 - Add Ruby 3.1, 3.2, and JRuby 9.4 to the CI matrix.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,12 @@ workflows:
           name: Ruby 3.0
           docker-image: cimg/ruby:3.0
       - build-test-linux:
+          name: Ruby 3.1
+          docker-image: cimg/ruby:3.1
+      - build-test-linux:
+          name: Ruby 3.2
+          docker-image: cimg/ruby:3.2
+      - build-test-linux:
           name: JRuby 9.2
           docker-image: jruby:9.2-jdk
           jruby: true
@@ -24,6 +30,11 @@ workflows:
       - build-test-linux:
           name: JRuby 9.3
           docker-image: jruby:9.3-jdk
+          jruby: true
+          skip-end-to-end-http-tests: "y"  # webrick doesn't work reliably in JRuby
+      - build-test-linux:
+          name: JRuby 9.4
+          docker-image: jruby:9.4-jdk
           jruby: true
           skip-end-to-end-http-tests: "y"  # webrick doesn't work reliably in JRuby
 


### PR DESCRIPTION
Addresses #38 .  Haven't been able to run on a fork.  A little concerned about the locking of the bundler version in the CI script, and this may need updating to support recent Rubies.