### PR TITLE
feat: Add thread reader to client

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -141,8 +141,11 @@ module SSE
 
       yield self if block_given?
 
-      Thread.new { run_stream }.name = 'LD/SSEClient'
+      @thread = Thread.new { run_stream }
+      @thread.name = 'LD/SSEClient'
     end
+
+    attr_reader :thread
 
     #
     # Specifies a block or Proc to receive events from the stream. This will be called once for every


### PR DESCRIPTION
When stopping the client its thread continues working for some time. This is not a problem in production, but in tests it is. Webmock removes its stub after the test, while the thread is still working, so we sometimes receive such errors:

```log
#<Thread:0x0000761ef6935090@LD/SSEClient /usr/local/bundle/ruby/3.1.0/gems/ld-eventsource-2.2.3/lib/ld-eventsource/client.rb:144 run> terminated with exception (report_on_exception is true):
/usr/local/bundle/ruby/3.1.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/http_rb/webmock.rb:63:in `halt': Real HTTP connections are disabled. Unregistered request: GET http://localhost:3003/admin/v1/emails with headers {'Accept'=>'text/event-stream', 'Authorization'=>'Bearer test_key', 'Cache-Control'=>'no-cache', 'Connection'=>'close', 'Host'=>'localhost:3003', 'Last-Event-Id'=>'0', 'User-Agent'=>'ruby-eventsource'} (WebMock::NetConnectNotAllowedError)
```

This PR adds a reader for thread, so it can be killed after the test example.

```ruby
subject(:call_method) do
  processor.start
  sleep 0.1
end

after do
  processor.connection.thread&.kill
end
```