### PR TITLE
fix: Remove rake dependency from gemspec

### DIFF
--- a/ld-eventsource.gemspec
+++ b/ld-eventsource.gemspec
@@ -3,7 +3,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ld-eventsource/version"
-require "rake"
 
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
@@ -16,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/launchdarkly/ruby-eventsource"
   spec.license       = "Apache-2.0"
 
-  spec.files         = FileList["lib/**/*", "README.md", "LICENSE"]
+  spec.files         = Dir.glob("lib/**/*") + ["README.md", "LICENSE"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
It breaks build from git repo in Docker

Ruby: 3.1.7

```ruby
gem "ld-eventsource", git: "https://github.com/launchdarkly/ruby-eventsource", branch: "main"
```

```log
#15 2.466 Fetching gem metadata from https://rubygems.org/........
#15 6.024 Fetching https://github.com/launchdarkly/ruby-eventsource
#15 7.026 
#15 7.026 [!] There was an error while loading `ld-eventsource.gemspec`: cannot load such file -- rake. Bundler cannot continue.
#15 7.026 
#15 7.026  #  from /usr/local/bundle/ruby/3.1.0/bundler/gems/ruby-eventsource-e58c181a039c/ld-eventsource.gemspec:6
#15 7.026  #  -------------------------------------------
#15 7.026  #  require "ld-eventsource/version"
#15 7.026  >  require "rake"
#15 7.026  #  
#15 7.026  #  -------------------------------------------
#15 ERROR: process "/bin/sh -c bundle install &&     rm -rf ~/.bundle/ \"${BUNDLE_PATH}\"/ruby/*/cache \"${BUNDLE_PATH}\"/ruby/*/bundler/gems/*/.git &&     bundle exec bootsnap precompile --gemfile" did not complete successfully: exit code: 14
```

There is no need for using `rake`, `Dir.glob` does the same job