### PR TITLE
fix: Update `force_encoding` to operate on unfrozen string

### DIFF
--- a/lib/ld-eventsource/impl/buffered_line_reader.rb
+++ b/lib/ld-eventsource/impl/buffered_line_reader.rb
@@ -22,8 +22,8 @@ module SSE
 
         Enumerator.new do |gen|
           chunks.each do |chunk|
-            chunk.force_encoding("ASCII-8BIT")
-            buffer << chunk
+            chunk = chunk.dup.force_encoding("ASCII-8BIT")
+            buffer += chunk
 
             loop do
               # Search for a line break in any part of the buffer that we haven't yet seen.


### PR DESCRIPTION
Similar to the work done in ccf79af, we are updating this library to
handle the upcoming change where strings are frozen by default.
