### PR TITLE
fix: Add `logger` as explicit dependency

### DIFF
--- a/ld-eventsource.gemspec
+++ b/ld-eventsource.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.1'
 
+  spec.add_development_dependency 'logger', '~> 1.5'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'
   spec.add_development_dependency "rubocop", "~> 1.37"


### PR DESCRIPTION
Starting in 3.5.0, `logger` will no longer be a part of the default
gems. v1.5 of the logger was shipped with Ruby 3.1.0, so this should
maintain equivalent functionality.
