### PR TITLE
chore: Setting permissions for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,13 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 on:
   workflow_dispatch:
   schedule:
     # Happen once per day at 1:30 AM
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   sdk-close-stale:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk YAML change to a GitHub Actions workflow; main effect is enabling the stale action to write to issues and PRs.
> 
> **Overview**
> Updates `.github/workflows/stale.yml` to standardize YAML quoting and explicitly add `permissions` for `issues: write` and `pull-requests: write`, ensuring the reusable stale workflow can close/update issues and PRs when running on the schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61e91ad26c626cef56ef907402234b34ea031ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->